### PR TITLE
Fix_adhesion#303

### DIFF
--- a/src/Entity/Attended.php
+++ b/src/Entity/Attended.php
@@ -29,6 +29,7 @@ class Attended
      * @ORM\Column(type="date")
      * @Assert\NotBlank(message="Merci d'indiquer une date de fin")
      * @Assert\Date(message = "Veuillez indiquer une date valide")
+     * @Assert\GreaterThan(propertyPath="beginDate")
      */
     private $endDate;
 


### PR DESCRIPTION
le contrôle sur la date de fin se fait dans les assert. On ne peut pas mettre une date de fin antérierue à celle du début